### PR TITLE
Use correct dependency order to fix OAuth login problem

### DIFF
--- a/site/oauth.html
+++ b/site/oauth.html
@@ -60,8 +60,8 @@ the License. -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
     <!-- Include all compiled plugins (below), or include individual files as needed -->
     <script src="js/bootstrap.min.js"></script>
+    <script src="js/config.js"></script>
     <script src="js/ponymail.js"></script>
     <script src="js/oauth.js"></script>
-    <script src="js/config.js"></script>
   </body>
 </html>


### PR DESCRIPTION
OAuth login does not presently work if configured in `config.js`. The issue is that constructing OAuth login URLs in `oauth.html` requires the data in `config.js` to be manipulated by the code in `oauth.js`, but the dependencies are in the wrong order in `oauth.html`. This branch and pull request fixes that dependency order to enable OAuth to work properly.