### PR TITLE
Fix setup arguments checking

### DIFF
--- a/tools/setup.py
+++ b/tools/setup.py
@@ -122,7 +122,7 @@ if args.defaults:
     urlPrefix = ''
 
 # Accept CLI args, copy them
-if args.dbprefix:
+if args.dbprefix != None:
     urlPrefix = args.dbprefix
 if args.dbhost:
     hostname = args.dbhost
@@ -140,7 +140,7 @@ if args.nwc:
     wc = False
 if args.dbshards:
     shards = args.dbshards
-if args.dbreplicas:
+if args.dbreplicas != None:
     replicas = args.dbreplicas
 if args.generator:
     genname = args.generator


### PR DESCRIPTION
This patch fixes a minor issue for setup.py: with it, when specifying `''` (empty string) for `--dbprefix` or `0` for `--dbreplicas`, the script still asks for those values, which break automatic setups.

